### PR TITLE
Select by selection

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
     "@babel/runtime-corejs2": "^7.11.2",
     "@turf/boolean-disjoint": "^6.0.2",
     "@turf/buffer": "^6.5.0",
+    "@turf/helpers": "^6.5.0",
+    "@turf/meta": "^6.5.0",
     "npm-run-all": "^4.1.5",
     "whatwg-fetch": "^2.0.4"
   },


### PR DESCRIPTION
Closes #15.

Adds new functionality by using an existing selection or search result as input to buffer tool.  When buffer tool is selected and there is a present selection, either by search result or previous selection, the combined geometry of the selection is used as input to buffer tool instead of letting the user select a feature to buffer.

It is not possible to make the selection using normal feature info or a search before activating multiselect because Origo always closes the featureInfo window when toggling tool. (May soon appear as an issue in origo)

This PR does not require nor support any configuration changes. 