### PR TITLE
feat: export selection (GeoJSON, CSV, Excel) issue 49

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,11 @@ The optional argument to Multiselect is an object which can have the following p
 | pointBufferFactor  | How much a point should be buffered before intersecting when using click tool. Does not apply if active configuration is "All visible", as that uses featureInfo hitTolerance setting. | 1                       |
 | bufferSymbol       | Name of a symbol in origo configuration to use as symbol for buffered objects. Symbol is always a polygon.                                                                             | A built-in symbol       |
 | chooseSymbol       | Name of a symbol in origo configuration to use as symbol for highlighted features when choosing which feature to buffer. Symbol should handle point, line and polygon.                 | A built-in symbol       |
-| warnOnNoHits       | Whether an alert should be displayed when no features to select are found.                                                                                                             | `false`                 |                                                                                                                                           | `true`                  |
+| warnOnNoHits       | Whether an alert should be displayed when no features to select are found.                                                                                                             | `false`                 |
+| showExportButton   | Show a button to export the selection (GeoJSON, CSV, Excel).                                                                                                                           | `false`                 |
+| exportFormats      | Which export formats to offer. Array of `'geojson'`, `'csv'`, `'excel'`.                                                                                                               | All three               |
+| exportFilename     | Base filename for exported files (extension added automatically). Invalid path characters are stripped.                                                                                | `'selected-features'`   |
+| csvIncludeWkt      | Include a WKT geometry column in CSV export.                                                                                                                                           | `true`                  |
 
 #### layerConfiguration
 A layerConfiguration specifies in which layers features are selected. The default behaviour is to select features in all currently visible
@@ -110,5 +114,4 @@ const selectableLayers = [
 - WMS layers are supported if there is a WFS endpoint at the same URL as the WMS source. 
 - WMS layers must have same default SRS as the map
 - WFS layers must have the same default SRS as the map if using bbox strategy and a layerConfiguration that uses the layer property.
-- When using the default All visible configuration and WFS layers are using bbox strategy and and selecting with a larger object than visible on the screen (e.g. using a big buffer), objects outside the screen are not selected if they haven't been read before in another extent. 
-
+- When using the default All visible configuration and WFS layers are using bbox strategy and and selecting with a larger object than visible on the screen (e.g. using a big buffer), objects outside the screen are not selected if they haven't been read before in another extent.

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,13 +12,17 @@
         "@turf/boolean-disjoint": "^6.0.2",
         "@turf/buffer": "^6.5.0",
         "@turf/helpers": "^6.5.0",
-        "@turf/meta": "^6.5.0"
+        "@turf/meta": "^6.5.0",
+        "npm-run-all2": "^6.1.2",
+        "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz"
       },
       "devDependencies": {
         "compression-webpack-plugin": "^10.0.0",
         "eslint": "^8.56.0",
         "eslint-config-airbnb-base": "^15.0.0",
         "eslint-plugin-import": "^2.29.1",
+        "mini-css-extract-plugin": "^2.10.0",
+        "sass-embedded": "^1.86.3",
         "webpack": "^5.99.5",
         "webpack-bundle-analyzer": "^4.10.2",
         "webpack-cli": "^6.0.1",
@@ -34,6 +38,13 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/@bufbuild/protobuf": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.11.0.tgz",
+      "integrity": "sha512-sBXGT13cpmPR5BMgHE6UEEfEaShh5Ror6rfN3yEK5si7QVrtZg8LEPQb0VVhiLRUslD2yLnXtnRzG035J/mZXQ==",
+      "dev": true,
+      "license": "(Apache-2.0 AND BSD-3-Clause)"
     },
     "node_modules/@discoveryjs/json-ext": {
       "version": "0.5.7",
@@ -674,6 +685,64 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@parcel/watcher": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.6.tgz",
+      "integrity": "sha512-tmmZ3lQxAe/k/+rNnXQRawJ4NjxO2hqiOLTHvWchtGZULp4RyFeh6aU4XdOYBFe2KE1oShQTv4AblOs2iOrNnQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "detect-libc": "^2.0.3",
+        "is-glob": "^4.0.3",
+        "node-addon-api": "^7.0.0",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "@parcel/watcher-android-arm64": "2.5.6",
+        "@parcel/watcher-darwin-arm64": "2.5.6",
+        "@parcel/watcher-darwin-x64": "2.5.6",
+        "@parcel/watcher-freebsd-x64": "2.5.6",
+        "@parcel/watcher-linux-arm-glibc": "2.5.6",
+        "@parcel/watcher-linux-arm-musl": "2.5.6",
+        "@parcel/watcher-linux-arm64-glibc": "2.5.6",
+        "@parcel/watcher-linux-arm64-musl": "2.5.6",
+        "@parcel/watcher-linux-x64-glibc": "2.5.6",
+        "@parcel/watcher-linux-x64-musl": "2.5.6",
+        "@parcel/watcher-win32-arm64": "2.5.6",
+        "@parcel/watcher-win32-ia32": "2.5.6",
+        "@parcel/watcher-win32-x64": "2.5.6"
+      }
+    },
+    "node_modules/@parcel/watcher-win32-x64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-x64/-/watcher-win32-x64-2.5.6.tgz",
+      "integrity": "sha512-hbQlYcCq5dlAX9Qx+kFb0FHue6vbjlf0FrNzSKdYK2APUf7tGfGxQCk2ihEREmbR6ZMc0MVAD5RIX/41gpUzTw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
     "node_modules/@peculiar/asn1-cms": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/@peculiar/asn1-cms/-/asn1-cms-2.6.1.tgz",
@@ -1149,13 +1218,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.2.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.2.3.tgz",
-      "integrity": "sha512-m0jEgYlYz+mDJZ2+F4v8D1AyQb+QzsNqRuI7xg1VQX/KlKS0qT9r1Mo16yo5F/MtifXFgaofIFsdFMox2SxIbQ==",
+      "version": "25.3.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.3.3.tgz",
+      "integrity": "sha512-DpzbrH7wIcBaJibpKo9nnSQL0MTRdnWttGyE5haGwK86xgMOkFLp7vEyfQPGLOJh5wNYiJ3V9PmUMDhV9u8kkQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.16.0"
+        "undici-types": "~7.18.0"
       }
     },
     "node_modules/@types/qs": {
@@ -1485,9 +1554,9 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.15.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
-      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -1606,16 +1675,12 @@
       }
     },
     "node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
       "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
       "engines": {
-        "node": ">=8"
+        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
@@ -1828,17 +1893,19 @@
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.9.19",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.19.tgz",
-      "integrity": "sha512-ipDqC8FrAl/76p2SSWKSI+H9tFwm7vYqXQrItCuiVPt26Km0jS+NzSsBWAaBusvSbQcfJG+JitdMm+wZAgTYqg==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.0.tgz",
+      "integrity": "sha512-lIyg0szRfYbiy67j9KN8IyeD7q7hcmqnJ1ddWmNt19ItGpNN64mnllmxUNFIOdOm6by97jlL6wfpTTJrmnjWAA==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
-        "baseline-browser-mapping": "dist/cli.js"
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/batch": {
@@ -2084,9 +2151,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001770",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001770.tgz",
-      "integrity": "sha512-x/2CLQ1jHENRbHg5PSId2sXq1CIO1CISvwWAj027ltMVG2UNgW+w9oH2+HzgEIRFembL8bUlXtfbBHR1fCg2xw==",
+      "version": "1.0.30001776",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001776.tgz",
+      "integrity": "sha512-sg01JDPzZ9jGshqKSckOQthXnYwOEP50jeVFhaSFbZcOy05TiuuaffDOfcwtCisJ9kNQuLBFibYywv2Bgm9osw==",
       "dev": true,
       "funding": [
         {
@@ -2104,21 +2171,21 @@
       ],
       "license": "CC-BY-4.0"
     },
-    "node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+    "node_modules/chokidar": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
+        "readdirp": "^4.0.1"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">= 14.16.0"
       },
       "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/chrome-trace-event": {
@@ -2145,31 +2212,18 @@
         "node": ">=6"
       }
     },
-    "node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/colorette": {
       "version": "2.0.20",
       "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
       "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
       "dev": true
+    },
+    "node_modules/colorjs.io": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/colorjs.io/-/colorjs.io-0.5.2.tgz",
+      "integrity": "sha512-twmVoizEW7ylZSN32OgKdXRmo1qg+wT5/6C3xu5b9QsWzSFAhHLn2xd8ro0diCsKfCj1RdaTP/nrcW+vAoQPIw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/commander": {
       "version": "2.20.3",
@@ -2370,12 +2424,26 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
         "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/cross-spawn/node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
       },
       "engines": {
         "node": ">= 8"
@@ -2576,6 +2644,17 @@
         "npm": "1.2.8000 || >= 1.4.16"
       }
     },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/detect-node": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
@@ -2636,9 +2715,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.286",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.286.tgz",
-      "integrity": "sha512-9tfDXhJ4RKFNerfjdCcZfufu49vg620741MNs26a9+bhLThdB+plgMeou98CAaHu/WATj2iHOOHTp1hWtABj2A==",
+      "version": "1.5.302",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.302.tgz",
+      "integrity": "sha512-sM6HAN2LyK82IyPBpznDRqlTQAtuSaO+ShzFiWTvoMJLHyZ+Y39r8VMfHzwbU8MVBzQ4Wdn85+wlZl2TLGIlwg==",
       "dev": true,
       "license": "ISC"
     },
@@ -2653,9 +2732,9 @@
       }
     },
     "node_modules/enhanced-resolve": {
-      "version": "5.19.0",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.19.0.tgz",
-      "integrity": "sha512-phv3E1Xl4tQOShqSte26C7Fl84EwUdZsyOuSSk9qtAGyyQs2s3jJzComh+Abf4g187lUUAvH+H26omrqia2aGg==",
+      "version": "5.20.0",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.20.0.tgz",
+      "integrity": "sha512-/ce7+jQ1PQ6rVXwe+jKEg5hW5ciicHwIQUagZkp6IufBoY3YDgdTTY1azVs0qoRgVmvsNB+rbjLJxDAeHHtwsQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3049,6 +3128,55 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/eslint/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/eslint/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/eslint/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/eslint/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
     "node_modules/eslint/node_modules/doctrine": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
@@ -3157,6 +3285,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/espree": {
@@ -3541,6 +3681,21 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/flat-cache/node_modules/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "dev": true,
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/flatted": {
       "version": "3.2.9",
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.9.tgz",
@@ -3609,21 +3764,6 @@
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
-    },
-    "node_modules/fsevents": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
-      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
     },
     "node_modules/function-bind": {
       "version": "1.1.2",
@@ -4118,6 +4258,13 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immutable": {
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.4.tgz",
+      "integrity": "sha512-p6u1bG3YSnINT5RQmx/yRZBpenIl30kVxkTLDyHLIMk0gict704Q9n+thfDI7lTRm9vXdDYutVzXhzcThxTnXA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -4480,9 +4627,9 @@
       }
     },
     "node_modules/is-network-error": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/is-network-error/-/is-network-error-1.3.0.tgz",
-      "integrity": "sha512-6oIwpsgRfnDiyEDLMay/GqCl3HoAtH5+RUKW29gYkL0QA+ipzpDLA16yQs7/RHCSu+BwgbJaOUqa4A99qNVQVw==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/is-network-error/-/is-network-error-1.3.1.tgz",
+      "integrity": "sha512-6QCxa49rQbmUWLfk0nuGqzql9U8uaV2H6279bRErPBHe/109hCzsLUBUHfbEtvLIHBd6hyXbgedBSHevm43Edw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4725,7 +4872,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/isobject": {
@@ -4751,22 +4897,6 @@
       },
       "engines": {
         "node": ">= 10.13.0"
-      }
-    },
-    "node_modules/jest-worker/node_modules/supports-color": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
-      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
     "node_modules/js-yaml": {
@@ -4833,6 +4963,7 @@
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
       "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4942,6 +5073,14 @@
         "tslib": "2"
       }
     },
+    "node_modules/memorystream": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/memorystream/-/memorystream-0.3.1.tgz",
+      "integrity": "sha512-S3UwM3yj5mtUSEfP41UZmt/0SCoVYUcU1rkXv+BQ5Ig8ndL4sPoJNBUJERafdPb5jjHJGuMgytgKvKIf58XNBw==",
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
     "node_modules/merge-descriptors": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
@@ -5030,6 +5169,27 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/mini-css-extract-plugin": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-2.10.0.tgz",
+      "integrity": "sha512-540P2c5dYnJlyJxTaSloliZexv8rji6rY8FhQN+WF/82iHQfA23j/xtJx97L+mXOML27EqksSek/g4eK7jaL3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "schema-utils": "^4.0.0",
+        "tapable": "^2.2.1"
+      },
+      "engines": {
+        "node": ">= 12.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependencies": {
+        "webpack": "^5.0.0"
+      }
+    },
     "node_modules/minimalistic-assert": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
@@ -5109,6 +5269,14 @@
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "dev": true
     },
+    "node_modules/node-addon-api": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
+      "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/node-releases": {
       "version": "2.0.27",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
@@ -5124,6 +5292,65 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm-normalize-package-bin": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-3.0.1.tgz",
+      "integrity": "sha512-dMxCf+zZ+3zeQZXKxmyuCKlIDPGuv8EF940xbkC4kQVDTtqoh6rJFO+JTKSA6/Rwi0getWmtuy4Itup0AMcaDQ==",
+      "license": "ISC",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/npm-run-all2": {
+      "version": "6.2.6",
+      "resolved": "https://registry.npmjs.org/npm-run-all2/-/npm-run-all2-6.2.6.tgz",
+      "integrity": "sha512-tkyb4pc0Zb0oOswCb5tORPk9MvVL6gcDq1cMItQHmsbVk1skk7YF6cH+UU2GxeNLHMuk6wFEOSmEmJ2cnAK1jg==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "cross-spawn": "^7.0.3",
+        "memorystream": "^0.3.1",
+        "minimatch": "^9.0.0",
+        "pidtree": "^0.6.0",
+        "read-package-json-fast": "^3.0.2",
+        "shell-quote": "^1.7.3",
+        "which": "^3.0.1"
+      },
+      "bin": {
+        "npm-run-all": "bin/npm-run-all/index.js",
+        "npm-run-all2": "bin/npm-run-all/index.js",
+        "run-p": "bin/run-p/index.js",
+        "run-s": "bin/run-s/index.js"
+      },
+      "engines": {
+        "node": "^14.18.0 || ^16.13.0 || >=18.0.0",
+        "npm": ">= 8"
+      }
+    },
+    "node_modules/npm-run-all2/node_modules/brace-expansion": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/npm-run-all2/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/object-inspect": {
@@ -5435,7 +5662,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -5460,6 +5686,32 @@
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pidtree": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/pidtree/-/pidtree-0.6.0.tgz",
+      "integrity": "sha512-eG2dWTVw5bzqGRztnHExczNxt5VGsE6OwTeCG3fdUf9KBsZzO3R5OIIIzWR+iZA0NtZ+RDVdaoE2dK1cn6jH4g==",
+      "license": "MIT",
+      "bin": {
+        "pidtree": "bin/pidtree.js"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
     },
     "node_modules/pkg-dir": {
       "version": "4.2.0",
@@ -5643,6 +5895,28 @@
         "quickselect": "^2.0.0"
       }
     },
+    "node_modules/read-package-json-fast": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/read-package-json-fast/-/read-package-json-fast-3.0.2.tgz",
+      "integrity": "sha512-0J+Msgym3vrLOUB3hzQCuZHII0xkNGCtz/HJH9xZshwv9DbDwkw1KaE3gx/e2J5rpEY5rtOy6cyhKOPrkP7FZw==",
+      "license": "ISC",
+      "dependencies": {
+        "json-parse-even-better-errors": "^3.0.0",
+        "npm-normalize-package-bin": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/read-package-json-fast/node_modules/json-parse-even-better-errors": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-3.0.2.tgz",
+      "integrity": "sha512-fi0NG4bPjCHunUJffmLd0gxssIgkNmArMvis4iNah6Owg1MCJjWhEcDLmsK6iGkJq3tHwbDkTlce70/tmXN4cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
     "node_modules/readable-stream": {
       "version": "2.3.7",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
@@ -5656,6 +5930,21 @@
         "safe-buffer": "~5.1.1",
         "string_decoder": "~1.1.1",
         "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 14.18.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/rechoir": {
@@ -5805,23 +6094,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/rimraf": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-      "deprecated": "Rimraf versions prior to v4 are no longer supported",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/run-applescript": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.1.0.tgz",
@@ -5856,6 +6128,16 @@
       ],
       "dependencies": {
         "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/rxjs": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
       }
     },
     "node_modules/safe-array-concat": {
@@ -5937,7 +6219,89 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/sass": {
+      "version": "1.97.3",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.97.3.tgz",
+      "integrity": "sha512-fDz1zJpd5GycprAbu4Q2PV/RprsRtKC/0z82z0JLgdytmcq0+ujJbJ/09bPGDxCLkKY3Np5cRAOcWiVkLXJURg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "chokidar": "^4.0.0",
+        "immutable": "^5.0.2",
+        "source-map-js": ">=0.6.2 <2.0.0"
+      },
+      "bin": {
+        "sass": "sass.js"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "optionalDependencies": {
+        "@parcel/watcher": "^2.4.1"
+      }
+    },
+    "node_modules/sass-embedded": {
+      "version": "1.97.3",
+      "resolved": "https://registry.npmjs.org/sass-embedded/-/sass-embedded-1.97.3.tgz",
+      "integrity": "sha512-eKzFy13Nk+IRHhlAwP3sfuv+PzOrvzUkwJK2hdoCKYcWGSdmwFpeGpWmyewdw8EgBnsKaSBtgf/0b2K635ecSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bufbuild/protobuf": "^2.5.0",
+        "colorjs.io": "^0.5.0",
+        "immutable": "^5.0.2",
+        "rxjs": "^7.4.0",
+        "supports-color": "^8.1.1",
+        "sync-child-process": "^1.0.2",
+        "varint": "^6.0.0"
+      },
+      "bin": {
+        "sass": "dist/bin/sass.js"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "optionalDependencies": {
+        "sass-embedded-all-unknown": "1.97.3",
+        "sass-embedded-android-arm": "1.97.3",
+        "sass-embedded-android-arm64": "1.97.3",
+        "sass-embedded-android-riscv64": "1.97.3",
+        "sass-embedded-android-x64": "1.97.3",
+        "sass-embedded-darwin-arm64": "1.97.3",
+        "sass-embedded-darwin-x64": "1.97.3",
+        "sass-embedded-linux-arm": "1.97.3",
+        "sass-embedded-linux-arm64": "1.97.3",
+        "sass-embedded-linux-musl-arm": "1.97.3",
+        "sass-embedded-linux-musl-arm64": "1.97.3",
+        "sass-embedded-linux-musl-riscv64": "1.97.3",
+        "sass-embedded-linux-musl-x64": "1.97.3",
+        "sass-embedded-linux-riscv64": "1.97.3",
+        "sass-embedded-linux-x64": "1.97.3",
+        "sass-embedded-unknown-all": "1.97.3",
+        "sass-embedded-win32-arm64": "1.97.3",
+        "sass-embedded-win32-x64": "1.97.3"
+      }
+    },
+    "node_modules/sass-embedded-win32-x64": {
+      "version": "1.97.3",
+      "resolved": "https://registry.npmjs.org/sass-embedded-win32-x64/-/sass-embedded-win32-x64-1.97.3.tgz",
+      "integrity": "sha512-SFRa2lED9UEwV6vIGeBXeBOLKF+rowF3WmNfb/BzhxmdAsKofCXrJ8ePW7OcDVrvNEbTOGwhsReIsF5sH8fVaw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=14.0.0"
+      }
     },
     "node_modules/schema-utils": {
       "version": "4.3.3",
@@ -6244,7 +6608,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -6257,7 +6620,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -6267,7 +6629,6 @@
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.1.tgz",
       "integrity": "sha512-6j1W9l1iAs/4xYBI1SYOVZyFcCis9b4KCLQ8fgAGG07QvzaRLVVRQvAy85yNmmZSjYjg4MWh4gNvlPujU/5LpA==",
-      "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -6373,6 +6734,27 @@
         "websocket-driver": "^0.7.4"
       }
     },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/source-map-support": {
       "version": "0.5.21",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
@@ -6382,16 +6764,6 @@
       "dependencies": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
-      }
-    },
-    "node_modules/source-map-support/node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/spdy": {
@@ -6565,16 +6937,19 @@
       }
     },
     "node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
     "node_modules/supports-preserve-symlinks-flag": {
@@ -6587,6 +6962,29 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/sync-child-process": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/sync-child-process/-/sync-child-process-1.0.2.tgz",
+      "integrity": "sha512-8lD+t2KrrScJ/7KXCSyfhT3/hRq78rC0wBFqNJXv3mZyn6hW2ypM05JmlSvtqRbeq6jqA94oHbxAr2vYsJ8vDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "sync-message-port": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/sync-message-port": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/sync-message-port/-/sync-message-port-1.2.0.tgz",
+      "integrity": "sha512-gAQ9qrUN/UCypHtGFbbe7Rc/f9bzO88IwrG8TDo/aMKAApKyD6E3W4Cm0EfhfBb6Z6SKt59tTCTfD+n1xmAvMg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/tapable": {
@@ -6917,9 +7315,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
-      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "dev": true,
       "license": "MIT"
     },
@@ -6998,6 +7396,13 @@
         "uuid": "dist/bin/uuid"
       }
     },
+    "node_modules/varint": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/varint/-/varint-6.0.0.tgz",
+      "integrity": "sha512-cXEIW6cfr15lFv563k4GuVuW/fiwjknytD37jIOLSdSWuOI6WnO/oKwmP2FQTU2l01LP8/M5TSAJpzUaGe3uWg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/vary": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
@@ -7032,9 +7437,9 @@
       }
     },
     "node_modules/webpack": {
-      "version": "5.105.2",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.105.2.tgz",
-      "integrity": "sha512-dRXm0a2qcHPUBEzVk8uph0xWSjV/xZxenQQbLwnwP7caQCYpqG1qddwlyEkIDkYn0K8tvmcrZ+bOrzoQ3HxCDw==",
+      "version": "5.105.3",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.105.3.tgz",
+      "integrity": "sha512-LLBBA4oLmT7sZdHiYE/PeVuifOxYyE2uL/V+9VQP7YSYdJU7bSf7H8bZRRxW8kEPMkmVjnrXmoR3oejIdX0xbg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7044,7 +7449,7 @@
         "@webassemblyjs/ast": "^1.14.1",
         "@webassemblyjs/wasm-edit": "^1.14.1",
         "@webassemblyjs/wasm-parser": "^1.14.1",
-        "acorn": "^8.15.0",
+        "acorn": "^8.16.0",
         "acorn-import-phases": "^1.0.3",
         "browserslist": "^4.28.1",
         "chrome-trace-event": "^1.0.2",
@@ -7062,7 +7467,7 @@
         "tapable": "^2.3.0",
         "terser-webpack-plugin": "^5.3.16",
         "watchpack": "^2.5.1",
-        "webpack-sources": "^3.3.3"
+        "webpack-sources": "^3.3.4"
       },
       "bin": {
         "webpack": "bin/webpack.js"
@@ -7463,19 +7868,18 @@
       }
     },
     "node_modules/which": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-3.0.1.tgz",
+      "integrity": "sha512-XA1b62dzQzLfaEOSQFTCOd5KFf/1VSzZo7/7TUjnya6u0vGGKzU96UQBZTAThCb2j4/xjBAyii1OhRLJEivHvg==",
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
       },
       "bin": {
-        "node-which": "bin/node-which"
+        "node-which": "bin/which.js"
       },
       "engines": {
-        "node": ">= 8"
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/which-boxed-primitive": {
@@ -7622,6 +8026,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/xlsx": {
+      "version": "0.20.3",
+      "resolved": "https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz",
+      "integrity": "sha512-oLDq3jw7AcLqKWH2AhCpVTZl8mf6X2YReP+Neh0SJUzV/BdZYjth94tG5toiMB1PPrYtxOCfaoUCkvtuH+3AJA==",
+      "license": "Apache-2.0",
+      "bin": {
+        "xlsx": "bin/xlsx.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -4,9 +4,12 @@
   "description": "",
   "main": "./multiselect.js",
   "scripts": {
-    "start": "npm run watch-js",
+    "start": "npm-run-all --parallel watch-js watch-sass",
     "watch-js": "webpack-dev-server --config ./tasks/webpack.dev.js --mode development",
-    "build": "webpack --config ./tasks/webpack.prod.js"
+    "watch-sass": "sass -w --load-path scss scss/multiselect.scss ../origo/plugins/multiselect.css",
+    "build-sass": "sass scss/multiselect.scss build/css/multiselect.css",
+    "prewatch-sass": "sass scss/multiselect.scss ../origo/plugins/multiselect.css",
+    "build": "webpack --config ./tasks/webpack.prod.js && npm run build-sass"
   },
   "author": "",
   "license": "MIT",
@@ -14,13 +17,17 @@
     "@turf/boolean-disjoint": "^6.0.2",
     "@turf/buffer": "^6.5.0",
     "@turf/helpers": "^6.5.0",
-    "@turf/meta": "^6.5.0"
+    "@turf/meta": "^6.5.0",
+    "npm-run-all2": "^6.1.2",
+    "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz"
   },
   "devDependencies": {
     "compression-webpack-plugin": "^10.0.0",
     "eslint": "^8.56.0",
     "eslint-config-airbnb-base": "^15.0.0",
     "eslint-plugin-import": "^2.29.1",
+    "mini-css-extract-plugin": "^2.10.0",
+    "sass-embedded": "^1.86.3",
     "webpack": "^5.99.5",
     "webpack-bundle-analyzer": "^4.10.2",
     "webpack-cli": "^6.0.1",

--- a/scss/_multiselect-export-modal.scss
+++ b/scss/_multiselect-export-modal.scss
@@ -1,0 +1,53 @@
+@use 'variables' as vars;
+
+/* Export panel (infowindow-like): avoid clipping buttons; content can grow.
+   !important used to override Origo's .o-ui font-size and related base styles. */
+.o-multiselect-infowindow-panel {
+    overflow: visible;
+    font-size: 12px !important;
+}
+.o-multiselect-infowindow-panel .o-multiselect-infowindow-content {
+    overflow: visible;
+    max-height: none;
+    padding: 0.5rem;
+    padding-bottom: 0.75rem; /* room for action buttons */
+    font-size: 12px !important;
+}
+.o-multiselect-infowindow-panel .o-multiselect-infowindow-content .flex.column {
+    min-height: 0; /* allow flex to size to content */
+}
+
+/* Override .o-ui label inside export modal */
+.o-multiselect-infowindow-panel label {
+    font-size: 12px !important;
+    font-weight: normal !important;
+    line-height: 1.5 !important;
+}
+
+/* Make o-button usable as text button in flex rows */
+.o-multiselect-button-wide {
+    border: 1px solid vars.$o-btn-color !important;
+}
+
+/* Blue/primary */
+.o-multiselect-button-primary {
+    background-color: vars.$o-btn-active-color !important;
+    color: vars.$o-btn-bg;
+}
+
+.o-multiselect-flex-1 {
+    flex: 1;
+}
+
+.o-multiselect-flex-gap-sm {
+    gap: .5rem;
+}
+
+/* Scrollable list when many properties */
+.o-multiselect-export-props-list {
+    max-height: 12rem;
+    overflow-y: auto;
+    overflow-x: hidden;
+    font-size: 12px !important;
+    font-weight: normal !important;
+}

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -1,0 +1,7 @@
+// Copied from origo 2026-02-17
+// buttons
+$o-btn-color: #424242;
+$o-btn-bg: #fff;
+$o-btn-active-color: #008ff5;
+$o-btn-hover-color: #eee;
+$o-btn-hover-bg: #424242;

--- a/scss/multiselect.scss
+++ b/scss/multiselect.scss
@@ -1,0 +1,2 @@
+@use 'variables';
+@use 'multiselect-export-modal';

--- a/src/multiselect.js
+++ b/src/multiselect.js
@@ -3,6 +3,7 @@ import buffer from '@turf/buffer';
 import disjoint from '@turf/boolean-disjoint';
 import { geometryCollection } from '@turf/helpers';
 import { featureEach } from '@turf/meta';
+import { utils as xlsxUtils, write as xlsxWrite } from 'xlsx';
 import * as defaultstyles from './defaultstyles';
 
 const Multiselect = function Multiselect(options = {}) {
@@ -64,6 +65,13 @@ const Multiselect = function Multiselect(options = {}) {
   const useWMSFeatureInfo = options.WMSHandling && options.WMSHandling.source === 'WMS';
   const alternativeLayerConfiguration = options.alternativeLayers || [];
   const showClearButton = options.showClearButton === true;
+  const showExportButton = options.showExportButton === true;
+  const allowedFormats = ['geojson', 'csv', 'excel'];
+  const exportFormats = Array.isArray(options.exportFormats) && options.exportFormats.length > 0
+    ? options.exportFormats.map((f) => String(f).toLowerCase()).filter((f) => allowedFormats.includes(f))
+    : [...allowedFormats];
+  const exportFilenameBase = (options.exportFilename != null ? String(options.exportFilename).trim().replace(/[/\\?*:|"]/g, '') : '') || 'selected-features';
+  const csvIncludeWkt = options.csvIncludeWkt !== false;
   const showAddToSelectionButton = options.showAddToSelectionButton === true;
   let addToSelection = options.addToSelection !== false;
   const warnOnNoHits = options.warnOnNoHits === true;
@@ -77,6 +85,121 @@ const Multiselect = function Multiselect(options = {}) {
    * Handle that spinner uses to cancel a pending spinner. There can be only one spinner at any given time as it is modal.
    */
   let timerId = 0;
+
+  let infowindowPanelIdCounter = 0;
+
+  /**
+   * Makes an element draggable by its header (element with id {elementId}-draggable) or the element itself.
+   * Mirrors Origo infowindow behaviour.
+   * @param {HTMLElement} elmnt - The container element to move
+   */
+  function makeElementDraggable(elmnt) {
+    let pos1 = 0;
+    let pos2 = 0;
+    let pos3 = 0;
+    let pos4 = 0;
+
+    function elementDrag(evt) {
+      const e = evt || window.event;
+      e.preventDefault();
+      pos1 = pos3 - e.clientX;
+      pos2 = pos4 - e.clientY;
+      pos3 = e.clientX;
+      pos4 = e.clientY;
+      elmnt.style.top = `${elmnt.offsetTop - pos2}px`;
+      elmnt.style.left = `${elmnt.offsetLeft - pos1}px`;
+    }
+
+    function closeDragElement() {
+      document.onmouseup = null;
+      document.onmousemove = null;
+    }
+
+    function dragMouseDown(evt) {
+      const e = evt || window.event;
+      e.preventDefault();
+      pos3 = e.clientX;
+      pos4 = e.clientY;
+      document.onmouseup = closeDragElement;
+      document.onmousemove = elementDrag;
+    }
+
+    const header = document.getElementById(`${elmnt.id}-draggable`);
+    if (header) {
+      header.onmousedown = dragMouseDown;
+    } else {
+      elmnt.onmousedown = dragMouseDown;
+    }
+  }
+
+  /**
+   * Creates a draggable panel with title and content (no header buttons; close via content e.g. Avbryt).
+   * @param {Object} opts
+   * @param {string} opts.targetId - Id of the parent element (e.g. viewer id)
+   * @param {string} opts.title - Title text in the header
+   * @param {string} opts.content - HTML string for the body
+   * @param {function} [opts.onClose] - Called when the panel is closed
+   * @returns {{ closeModal: function, getContentContainer: function }}
+   */
+  function createInfowindowLikePanel(opts) {
+    const targetId = opts.targetId;
+    const title = opts.title || '';
+    const content = opts.content || '';
+    const onClose = opts.onClose || (() => {});
+
+    const panelId = `o-multiselect-panel-${infowindowPanelIdCounter += 1}`;
+
+    const mainContainer = document.createElement('div');
+    mainContainer.id = panelId;
+    mainContainer.classList.add('sidebarcontainer', 'o-multiselect-infowindow-panel');
+    mainContainer.style.position = 'absolute';
+    mainContainer.style.zIndex = '1000';
+    mainContainer.style.minWidth = '280px';
+    mainContainer.style.maxWidth = '90vw';
+
+    const urvalContainer = document.createElement('div');
+    urvalContainer.classList.add('urvalcontainer');
+    urvalContainer.id = `${panelId}-draggable`;
+
+    const urvalTextNodeContainer = document.createElement('div');
+    urvalTextNodeContainer.classList.add('urval-textnode-container');
+    urvalTextNodeContainer.appendChild(document.createTextNode(title));
+    urvalContainer.appendChild(urvalTextNodeContainer);
+
+    const contentContainer = document.createElement('div');
+    contentContainer.classList.add('o-multiselect-infowindow-content');
+    contentContainer.innerHTML = content;
+
+    mainContainer.appendChild(urvalContainer);
+    mainContainer.appendChild(contentContainer);
+
+    makeElementDraggable(mainContainer);
+
+    const parent = document.getElementById(targetId);
+    if (parent) {
+      parent.appendChild(mainContainer);
+      // Center modal in viewer
+      const parentWidth = parent.offsetWidth || parent.clientWidth;
+      const parentHeight = parent.offsetHeight || parent.clientHeight;
+      const panelWidth = mainContainer.offsetWidth;
+      const panelHeight = mainContainer.offsetHeight;
+      mainContainer.style.top = `${Math.max(0, (parentHeight - panelHeight) / 2)}px`;
+      mainContainer.style.left = `${Math.max(0, (parentWidth - panelWidth) / 2)}px`;
+    }
+
+    function closeModal() {
+      if (mainContainer.parentElement) {
+        mainContainer.parentElement.removeChild(mainContainer);
+      }
+      onClose();
+    }
+
+    function getContentContainer() {
+      return contentContainer;
+    }
+
+    return { closeModal, getContentContainer };
+  }
 
   function setActive(state) {
     isActive = state;
@@ -96,6 +219,315 @@ const Multiselect = function Multiselect(options = {}) {
    * */
   function hasSelection() {
     return selectionManager.getSelectedItems().getLength() > 0 || featureInfo.getSelectionLayer().getSource().getFeatures().length > 0;
+  }
+
+  /**
+   * Returns all currently selected features as an array of OpenLayers features.
+   * Converts Circle geometries to Polygon for export compatibility.
+   * @returns {Origo.ol.Feature[]}
+   */
+  function getSelectedFeatures() {
+    const features = [];
+    const projection = map.getView().getProjection();
+
+    const fromSelectionLayer = featureInfo.getSelectionLayer().getSource().getFeatures();
+    fromSelectionLayer.forEach((f) => {
+      const clone = f.clone();
+      let geom = clone.getGeometry();
+      if (geom.getType() === 'Circle') {
+        geom = Origo.ol.geom.Polygon.fromCircle(geom);
+        clone.setGeometry(geom);
+      }
+      features.push(clone);
+    });
+
+    const selectedItems = selectionManager.getSelectedItems().getArray();
+    selectedItems.forEach((item) => {
+      const f = item.getFeature().clone();
+      let geom = f.getGeometry();
+      if (geom.getType() === 'Circle') {
+        geom = Origo.ol.geom.Polygon.fromCircle(geom);
+        f.setGeometry(geom);
+      }
+      features.push(f);
+    });
+
+    return features;
+  }
+
+  /**
+   * Opens a modal for the user to choose export format (GeoJSON, CSV, Excel), properties to include, then runs the export.
+   */
+  function showExportModal() {
+    if (!hasSelection()) {
+      return;
+    }
+    const features = getSelectedFeatures();
+    const attributeNames = getAttributeNames(features);
+
+    const formId = 'o-multiselect-export-form';
+    const wktRowId = 'o-multiselect-export-csv-wkt-row';
+    const propsListId = 'export-props-list';
+    const title = 'Exportera urval';
+    const formatLabels = { geojson: 'GeoJSON', csv: 'CSV', excel: 'Excel' };
+    const formatRadiosHtml = exportFormats.map((f, i) => {
+      const sep = i < exportFormats.length - 1 ? ' padding-right' : '';
+      const checked = i === 0 ? ' checked' : '';
+      return `<label class="inline${sep}"><input type="radio" name="export-format" value="${f}" id="export-format-${f}"${checked}> ${formatLabels[f] || f}</label>`;
+    }).join('\n          ');
+    const content = `
+      <div id="${formId}" class="flex column padding-small">
+        <div class="padding-bottom-small">
+          ${formatRadiosHtml}
+        </div>
+        <div id="${wktRowId}" class="padding-bottom-small hidden">
+          <label>
+            <input type="checkbox" id="export-csv-include-wkt" ${csvIncludeWkt ? 'checked' : ''}>
+            Inkludera geometri som WKT
+          </label>
+        </div>
+        <div class="padding-bottom-small">
+          <div class="flex row padding-bottom-smaller o-multiselect-flex-gap-sm">
+            <button type="button" id="export-props-select-all" class="o-button o-multiselect-button-wide o-multiselect-flex-1">Välj alla</button>
+            <button type="button" id="export-props-deselect-all" class="o-button o-multiselect-button-wide o-multiselect-flex-1">Avmarkera alla</button>
+          </div>
+          <div id="${propsListId}" class="o-multiselect-export-props-list padding-top-smaller"></div>
+        </div>
+        <div class="flex row justify-end padding-top-small o-multiselect-flex-gap-sm">
+          <button type="button" id="export-modal-cancel-btn" class="o-button o-multiselect-button-wide o-multiselect-flex-1">Avbryt</button>
+          <button type="button" id="export-modal-export-btn" class="o-button o-multiselect-button-wide o-multiselect-button-primary o-multiselect-flex-1">Exportera</button>
+        </div>
+      </div>`;
+
+    const modal = createInfowindowLikePanel({
+      targetId: viewer.getId(),
+      title,
+      content
+    });
+
+    const propsListEl = document.getElementById(propsListId);
+    attributeNames.forEach((name) => {
+      const label = document.createElement('label');
+      label.className = 'block padding-bottom-smaller';
+      const input = document.createElement('input');
+      input.type = 'checkbox';
+      input.name = 'export-prop';
+      input.value = name;
+      input.checked = true;
+      label.appendChild(input);
+      label.appendChild(document.createTextNode(` ${name}`));
+      propsListEl.appendChild(label);
+    });
+
+    document.getElementById('export-props-select-all').addEventListener('click', () => {
+      propsListEl.querySelectorAll('input[name="export-prop"]').forEach((cb) => { cb.checked = true; });
+    });
+    document.getElementById('export-props-deselect-all').addEventListener('click', () => {
+      propsListEl.querySelectorAll('input[name="export-prop"]').forEach((cb) => { cb.checked = false; });
+    });
+
+    const wktRowEl = document.getElementById(wktRowId);
+
+    function toggleWktRow() {
+      const formatCsvEl = document.getElementById('export-format-csv');
+      const showWkt = formatCsvEl?.checked || false;
+      if (showWkt) {
+        wktRowEl.classList.remove('hidden');
+      } else {
+        wktRowEl.classList.add('hidden');
+      }
+    }
+
+    exportFormats.forEach((f) => {
+      const el = document.getElementById(`export-format-${f}`);
+      if (el) el.addEventListener('change', toggleWktRow);
+    });
+    toggleWktRow();
+
+    document.getElementById('export-modal-export-btn').addEventListener('click', () => {
+      const selectedFormat = document.querySelector(`#${formId} input[name="export-format"]:checked`)?.value;
+      const includeWkt = selectedFormat === 'csv' && document.getElementById('export-csv-include-wkt').checked;
+      const selectedProps = Array.from(propsListEl.querySelectorAll('input[name="export-prop"]:checked')).map((cb) => cb.value);
+      const props = selectedProps.length > 0 ? selectedProps : null;
+      modal.closeModal();
+      if (selectedFormat === 'csv') {
+        exportToCSV(includeWkt, props);
+      } else if (selectedFormat === 'excel') {
+        exportToExcel(props);
+      } else {
+        exportToGeoJSON(props);
+      }
+    });
+
+    document.getElementById('export-modal-cancel-btn').addEventListener('click', () => {
+      modal.closeModal();
+    });
+  }
+
+  /**
+   * Exports selected features as GeoJSON and triggers a file download.
+   * @param {string[]|null} attributeNames - If provided, only these properties are included in each feature. Null = all properties.
+   */
+  function exportToGeoJSON(attributeNames) {
+    const features = getSelectedFeatures();
+    if (features.length === 0) {
+      return;
+    }
+    const projection = map.getView().getProjection();
+    let featuresToWrite = features;
+    if (attributeNames && attributeNames.length > 0) {
+      const nameSet = new Set(attributeNames);
+      featuresToWrite = features.map((f) => {
+        const clone = f.clone();
+        const props = clone.getProperties();
+        Object.keys(props).forEach((key) => {
+          if (key !== 'geometry' && !nameSet.has(key)) {
+            clone.unset(key);
+          }
+        });
+        return clone;
+      });
+    }
+    const format = new Origo.ol.format.GeoJSON();
+    const geojsonStr = format.writeFeatures(featuresToWrite, {
+      featureProjection: projection,
+      dataProjection: 'EPSG:4326'
+    });
+    const blob = new Blob([geojsonStr], { type: 'application/geo+json' });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = `${exportFilenameBase}.geojson`;
+    link.click();
+    URL.revokeObjectURL(url);
+  }
+
+  /**
+   * Returns unique attribute names from all features (excluding geometry).
+   * Order: first occurrence across features.
+   * @param {Origo.ol.Feature[]} features
+   * @returns {string[]}
+   */
+  function getAttributeNames(features) {
+    const seen = new Set();
+    const names = [];
+    features.forEach((f) => {
+      const props = f.getProperties();
+      Object.keys(props).forEach((key) => {
+        if (key === 'geometry' || props[key] instanceof Origo.ol.geom.Geometry) {
+          return;
+        }
+        if (!seen.has(key)) {
+          seen.add(key);
+          names.push(key);
+        }
+      });
+    });
+    return names;
+  }
+
+  /**
+   * Writes geometry as WKT in EPSG:4326.
+   * @param {Origo.ol.geom.Geometry} geometry
+   * @param {string} projection
+   * @returns {string}
+   */
+  function geometryToWkt(geometry, projection) {
+    const wktFormat = new Origo.ol.format.WKT();
+    const clone = geometry.clone();
+    clone.transform(projection, 'EPSG:4326');
+    return wktFormat.writeGeometry(clone);
+  }
+
+  /**
+   * Escapes a value for CSV: wraps in double quotes when value contains comma, newline or double quote,
+   * and doubles any internal double quotes per RFC 4180.
+   * @param {*} value
+   * @returns {string}
+   */
+  function escapeCsvValue(value) {
+    if (value === null || value === undefined) {
+      return '';
+    }
+    const str = String(value);
+    const needsQuoting = /[",\r\n]/.test(str);
+    const escaped = str.replace(/"/g, '""');
+    return needsQuoting ? `"${escaped}"` : escaped;
+  }
+
+  /**
+   * Exports selected features as CSV. Optionally includes geometry as WKT column.
+   * @param {boolean} includeWkt
+   * @param {string[]|null} attributeNames - If provided, only these columns are included. Null = all attributes.
+   */
+  function exportToCSV(includeWkt, attributeNames) {
+    const features = getSelectedFeatures();
+    if (features.length === 0) {
+      return;
+    }
+    const projection = map.getView().getProjection();
+    const attrNames = attributeNames && attributeNames.length > 0
+      ? attributeNames
+      : getAttributeNames(features);
+    const headers = includeWkt ? [...attrNames, 'wkt'] : attrNames;
+    const headerRow = headers.map((h) => escapeCsvValue(h)).join(',');
+    const rows = [headerRow];
+
+    features.forEach((feature) => {
+      const props = feature.getProperties();
+      const cells = attrNames.map((name) => escapeCsvValue(props[name]));
+      if (includeWkt) {
+        const geom = feature.getGeometry();
+        cells.push(escapeCsvValue(geom ? geometryToWkt(geom, projection) : ''));
+      }
+      rows.push(cells.join(','));
+    });
+
+    const csvStr = rows.join('\r\n');
+    const blob = new Blob([csvStr], { type: 'text/csv;charset=utf-8' });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = `${exportFilenameBase}.csv`;
+    link.click();
+    URL.revokeObjectURL(url);
+  }
+
+  /**
+   * Exports selected features as Excel (.xlsx). Only attribute columns are included (no geometry/WKT).
+   * @param {string[]|null} attributeNames - If provided, only these columns are included. Null = all attributes.
+   */
+  function exportToExcel(attributeNames) {
+    const features = getSelectedFeatures();
+    if (features.length === 0) {
+      return;
+    }
+    const attrNames = attributeNames && attributeNames.length > 0
+      ? attributeNames
+      : getAttributeNames(features);
+    const headers = [...attrNames];
+    const rows = [headers];
+
+    features.forEach((feature) => {
+      const props = feature.getProperties();
+      const cells = attrNames.map((name) => {
+        const v = props[name];
+        return v === null || v === undefined ? '' : v;
+      });
+      rows.push(cells);
+    });
+
+    const ws = xlsxUtils.aoa_to_sheet(rows);
+    const wb = xlsxUtils.book_new();
+    xlsxUtils.book_append_sheet(wb, ws, 'Data');
+    const xlsxData = xlsxWrite(wb, { bookType: 'xlsx', type: 'array' });
+    const blob = new Blob([xlsxData], { type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = `${exportFilenameBase}.xlsx`;
+    link.click();
+    URL.revokeObjectURL(url);
   }
 
   function displayTemporaryFeature(feature, style) {
@@ -1211,6 +1643,19 @@ const Multiselect = function Multiselect(options = {}) {
             tooltipPlacement: 'east'
           });
           buttons.push(clearButton);
+        }
+
+        if (showExportButton) {
+          const exportButton = Origo.ui.Button({
+            cls: 'o-multiselect-export padding-small margin-bottom-smaller icon-smaller round light box-shadow hidden',
+            click() {
+              showExportModal();
+            },
+            icon: '<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="M19 9h-4V3H9v6H5l7 7 7-7zM5 18v2h14v-2H5z"/></svg>',
+            tooltipText: 'Exportera urval',
+            tooltipPlacement: 'east'
+          });
+          buttons.push(exportButton);
         }
 
         if (defaultTool === 'click') {

--- a/tasks/webpack.dev.js
+++ b/tasks/webpack.dev.js
@@ -6,12 +6,27 @@ module.exports = merge(common, {
     path: `${__dirname}/../../origo/plugins`,
     publicPath: '/build/js',
     filename: 'multiselect.js',
-    libraryTarget: 'var',
+    libraryTarget: 'umd',
     libraryExport: 'default',
-    library: 'Multiselect'
+    library: 'Multiselect',
+    globalObject: 'this'
   },
   mode: 'development',
-  module: {},
+  module: {
+    rules: [{
+      test: /\.scss$/,
+      use: [{
+        loader: 'style-loader'
+      },
+      {
+        loader: 'css-loader'
+      },
+      {
+        loader: 'sass-loader'
+      }
+      ]
+    }]
+  },
 
   devServer: {
     static: './',

--- a/tasks/webpack.prod.js
+++ b/tasks/webpack.prod.js
@@ -1,6 +1,8 @@
 const webpack = require('webpack');
 const { merge } = require('webpack-merge');
 const common = require('./webpack.common');
+const MiniCssExtractPlugin = require('mini-css-extract-plugin');
+
 
 module.exports = merge(common, {
   optimization: {
@@ -13,15 +15,28 @@ module.exports = merge(common, {
   output: {
     path: `${__dirname}/../build/js`,
     filename: 'multiselect.min.js',
-    libraryTarget: 'var',
+    libraryTarget: 'umd',
     libraryExport: 'default',
-    library: 'Multiselect'
+    library: 'Multiselect',
+    globalObject: 'this'
   },
   devtool: false,
   mode: 'production',
   module: {
+    rules: [
+      {
+        test: /\.(sc|c)ss$/,
+        use: [{
+          loader: MiniCssExtractPlugin.loader
+        }
+        ]
+      }
+    ]
   },
   plugins: [
-    new webpack.optimize.AggressiveMergingPlugin()
+    new webpack.optimize.AggressiveMergingPlugin(),
+    new MiniCssExtractPlugin({
+      filename: '../css/multiselect.css'
+    }),
   ]
 });


### PR DESCRIPTION
## Summary
- Add export functionality to multiselect with a dedicated export modal (hidden by default for backward compatibility via showExportButton: false unless explicitly enabled).
- Support multiple export formats and configuration:
- GeoJSON
- CSV (optional WKT geometry column)
- Excel (attributes only, no WKT)
- Configurable allowed formats via exportFormats (defaults to all).
- Add property-selection UI in the export modal so users can choose which attributes to include in exports.
- Add configurable export filename base via exportFilename (extension added per format and filename sanitized).
- Add Excel export using xlsx and update bundling/import usage for the new dependency.
- Add modal-related styling updates (button classes and scrollable property list for large attribute sets).

## Backward compatibility

- Export UI is opt-in (showExportButton defaults to disabled).
- Existing multiselect behavior remains unchanged unless export is enabled.

## Configuration examples

- Enable export button:
  - `showExportButton: true`
- Restrict formats:
  - `exportFormats: ['geojson', 'csv']`
- Default filename base:
  - `exportFilename: 'my-selection'`
- CSV WKT default:
  - `csvIncludeWkt: true`